### PR TITLE
Image: Support search path

### DIFF
--- a/src/java/org/jlab/wedm/persistence/io/EDLParser.java
+++ b/src/java/org/jlab/wedm/persistence/io/EDLParser.java
@@ -148,7 +148,7 @@ public class EDLParser {
     }
 
     /**
-     * Resolve name to URL
+     * Resolve *.edl name to URL
      *
      * @param name Name may be a http:, https:, file: URL, but also just a name
      * that refers to a local file, or that is found on the EDMDATAFILES search
@@ -157,6 +157,20 @@ public class EDLParser {
      * @throws MalformedURLException
      */
     public static URL getEdlURL(String name) throws MalformedURLException {
+        return getURL(name, true);
+    }
+
+    /**
+     * Resolve name to URL
+     *
+     * @param name Name may be a http:, https:, file: URL, but also just a name
+     * that refers to a local file, or that is found on the EDMDATAFILES search
+     * path.
+     * @param force_edl Add *.edl suffix if not already in name?
+     * @return Resolved URL for the name or <code>null</code>
+     * @throws MalformedURLException
+     */
+    public static URL getURL(String name, final boolean force_edl) throws MalformedURLException {
         Objects.requireNonNull(name, "An EDL resource is required");
 
         // Use complete http.. URL as is
@@ -184,7 +198,7 @@ public class EDLParser {
         URL edl = null;
 
         // Assert that name has *.edl ending
-        if (!name.contains(".edl")) {
+        if (force_edl  &&  !name.contains(".edl")) {
             // The file extension should precede any macro following the resource name
             final int idx = name.indexOf("&");
             if (idx != -1) {

--- a/src/java/org/jlab/wedm/persistence/io/IOUtil.java
+++ b/src/java/org/jlab/wedm/persistence/io/IOUtil.java
@@ -1,9 +1,11 @@
 package org.jlab.wedm.persistence.io;
 
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,6 +67,33 @@ public final class IOUtil {
         }
 
         return bytes;
+    }
+
+    /**
+     * Read input stream as byte array
+     * @param stream Input stream
+     * @return The bytes
+     * @throws IOException on error
+     */   
+    public static byte[] streamToBytes(final InputStream stream) throws IOException
+    {
+        final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        try
+        {
+            final byte[] section = new byte[4096];
+            int len;
+            while ((len = stream.read(section)) >= 0)
+                buf.write(section, 0, len);
+            buf.flush();
+            buf.close();
+        }
+        finally
+        {
+            closeQuietly(stream);
+        }
+
+        return buf.toByteArray();
     }
     
     /**

--- a/src/java/org/jlab/wedm/widget/html/ActiveImage.java
+++ b/src/java/org/jlab/wedm/widget/html/ActiveImage.java
@@ -2,6 +2,7 @@ package org.jlab.wedm.widget.html;
 
 import java.awt.Point;
 import java.io.File;
+import java.net.URL;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,27 +36,34 @@ public class ActiveImage extends HtmlScreenObject {
 
         // TODO: it would be faster to load pages if we allowed the browser to fetch images asyncronously
         try {
-            file = EDLParser.rewriteFileName(file);
-            
-            File path = new File(file);
-
-            if (!path.isAbsolute()) {
-                path = new File(EDLParser.EDL_ROOT_DIR + File.separator + file);
-            }
-
             String type = null;
             
-            if(path.getName().endsWith(".gif")) {
+            if(file.contains(".gif")) {
                 type = "gif";
-            } else if(path.getName().endsWith(".png")) {
+            } else if(file.contains(".png")) {
                 type = "png";
             }
             
             if(type == null) {
-                throw new RuntimeException("Unsupported image type: " + path.getName());
+                throw new RuntimeException("Unsupported image type: " + file);
             }
-            
-            String contents = IOUtil.encodeBase64(IOUtil.fileToBytes(path));
+
+            String contents;
+            // Check local file
+            File path = new File(file);
+            if (!path.isAbsolute()) {
+                path = new File(EDLParser.EDL_ROOT_DIR + File.separator + file);
+            }
+            if (path.canRead()) {
+                contents = IOUtil.encodeBase64(IOUtil.fileToBytes(path));
+            }
+            else {
+                // Check URL, using search path etc.
+                final URL url = EDLParser.getURL(EDLParser.rewriteFileName(file), false);
+                if (url == null)
+                    throw new Exception("Cannot locate image " + file);
+                contents = IOUtil.encodeBase64(IOUtil.streamToBytes(url.openStream()));
+            }
             
             imgHtml = "<img width=\"100%\" height=\"100%\" src=\"data:image/" + type + ";base64," + contents + "\"></img>\n";
 

--- a/src/java/org/jlab/wedm/widget/html/ActiveImage.java
+++ b/src/java/org/jlab/wedm/widget/html/ActiveImage.java
@@ -50,7 +50,7 @@ public class ActiveImage extends HtmlScreenObject {
 
             String contents;
             // Check local file
-            File path = new File(file);
+            File path = new File(EDLParser.rewriteFileName(file));
             if (!path.isAbsolute()) {
                 path = new File(EDLParser.EDL_ROOT_DIR + File.separator + file);
             }


### PR DESCRIPTION
A recent wedm update supports an EDMDATAFILES search path and EDMHTTPDOCROOT.
The EDM image widget (png, gif) translation to html, however, didn't support the search path.

This adds search path support to the EDM image widget translation.
The original support for local files should still work, verified with `screen?edl=wedm/objects/Image.edl`