### PR TITLE
Check http doc root

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ followed by
 using the order provided in the search path,
 until it succeeds to find the file.
 
+When `EDMHTTPDOCROOT` is defined, all complete URLs passed to WEDM via `...?edl=http:/...`
+must in fact start with the `EDMHTTPDOCROOT`. Other URLs will be rejected to prevent
+network attacks which try to use the WEDM host to probe URL access.
+
 Often it is convenient to ignore self-signed certificates.  This can be done by defining the environment variable **WEDM_DISABLE_CERTIFICATE_CHECK** to any value.
 
 ## See Also

--- a/src/java/org/jlab/wedm/persistence/io/EDLParser.java
+++ b/src/java/org/jlab/wedm/persistence/io/EDLParser.java
@@ -175,6 +175,12 @@ public class EDLParser {
 
         // Use complete http.. URL as is
         if (name.startsWith("http:") || name.startsWith("https:")) {
+            // .. except when files are hosted at a HTTP_DOC_ROOT,
+            // in which case all complete URLs must start there
+            if (HTTP_DOC_ROOT != null  &&  ! name.startsWith(HTTP_DOC_ROOT) {
+                LOGGER.log(Level.WARNING, "Rejecting URL {0}", name);
+                return null;
+            }
             LOGGER.log(Level.FINE, "Using {0} as provided", name);
             return new URL(name);
         }

--- a/src/java/org/jlab/wedm/persistence/io/EDLParser.java
+++ b/src/java/org/jlab/wedm/persistence/io/EDLParser.java
@@ -177,7 +177,7 @@ public class EDLParser {
         if (name.startsWith("http:") || name.startsWith("https:")) {
             // .. except when files are hosted at a HTTP_DOC_ROOT,
             // in which case all complete URLs must start there
-            if (HTTP_DOC_ROOT != null  &&  ! name.startsWith(HTTP_DOC_ROOT) {
+            if (HTTP_DOC_ROOT != null  &&  ! name.startsWith(HTTP_DOC_ROOT)) {
                 LOGGER.log(Level.WARNING, "Rejecting URL {0}", name);
                 return null;
             }


### PR DESCRIPTION
We're defining EDMHTTPDOCROOT (as we do with plain edm) to fetch *.edl files from a web server, and also use a search path.

This setup would allow evildoers to call us with `screen?edl=http://any_host/whatever`. The app would try to open that link, and then likely run into an error because the result is not a valid *.edl file. Nevertheless , IT support was worried that it allows using the WEDM host to probe arbitrary URLs, so this change checks:
If EDMHTTPDOCROOT is set, and `screen?edl=...` is called with a `http*` URL, then that URL must start like EDMHTTPDOCROOT. Other URLs are ignored, preventing misuse of WEDM to probe URLs.
When EDMHTTPDOCROOT is not set, there's no change.