### PR TITLE
Prevent HTML insertion from edl=..

### DIFF
--- a/src/main/java/org/jlab/wedm/persistence/io/EDLParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/EDLParser.java
@@ -173,6 +173,12 @@ public class EDLParser {
     public static URL getURL(String name, final boolean force_edl) throws MalformedURLException {
         Objects.requireNonNull(name, "An EDL resource is required");
 
+        // Block name that might contain HTML elements
+        if (name.contains("<")  ||  name.contains(">")) {
+            LOGGER.log(Level.WARNING, "Rejecting name {0} because it might inject HTML", name);
+            return null;
+        }
+
         // Use complete http.. URL as is
         if (name.startsWith("http:") || name.startsWith("https:")) {
             // .. except when files are hosted at a HTTP_DOC_ROOT,

--- a/src/main/webapp/WEB-INF/views/screen.jsp
+++ b/src/main/webapp/WEB-INF/views/screen.jsp
@@ -6,7 +6,16 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>WEDM - ${screen.title ne null ? screen.title : param.edl}</title>
+        <%-- Show title from EDM display.
+             Fall back to filename, but prevent HTML insertion.
+          --%>
+        <title>WEDM - ${screen.title ne null
+                        ? screen.title
+                        : ( param.edl.contains("<") || param.edl.contains("<")
+                            ? ""
+                            : param.edl
+                          )
+                       }</title>
         <link rel="stylesheet" type="text/css" href="${wedm:contextPrefix()}/epics2web/resources/css/epics2web.min.css?v=${initParam.epics2webReleaseNumber}"/>
         <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/resources/css/screen.css?v=${initParam.releaseNumber}"/>
         <c:choose>


### PR DESCRIPTION
Our IT support identified a potential HTML insertion issue.

The filename is placed in the `<title>` of the generated HTML.
For example, access to `http://localhost:8080/wedm/screen?edl=bogus` will result in a page with `<title>WEDM - bogus</title>`.

An evildoer can insert HTML as in this example.
```
http://localhost:8080/wedm/screen?
edl=</title><script>alert(document.domain)</script>
```
Some web browsers now start to block `alert`, but the point is that you can insert HTML, including scripts, which the client will execute.

This PR blocks edl names with '<' or '>' at two levels: It refuses to parse those files, and it won't display the name as given.