### PR TITLE
Support relative path names

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ network attacks which try to use the WEDM host to probe URL access.
 
 Often it is convenient to ignore self-signed certificates.  This can be done by defining the environment variable **WEDM_DISABLE_CERTIFICATE_CHECK** to any value.
 
+### Relative path support
+EDM versions from 1-12-105J on (ca. June 2021) use this environment variable
+to enable support for relative path names:
+
+```
+EDMRELATIVEPATHS=yes
+```
+
+When relative paths are enabled, the names of embedded displays, images and
+links to related displays can be resolved relative to the display which contains them.
+
 ### Context Prefix
 When proxying WEDM it is sometimes useful to have multiple instances accessible via the same host via separate context paths.  In order to return correct links to resources an instance proxied with a namespacing prefix needs to be aware of the prefix.  The environment variable **CONTEXT_PREFIX** does this.  For example at Jefferson Lab we use a single proxy server for multiple departments each with their own instance of WEDM, and each configured with a prefix such as "/fel", "/chl", "/itf", and "/srf" ("/ops" uses default/empty prefix).
 

--- a/src/main/java/org/jlab/wedm/persistence/io/EDLParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/EDLParser.java
@@ -32,6 +32,7 @@ public class EDLParser {
     public static final String[] SEARCH_PATH;
     public static final String HTTP_DOC_ROOT;
     public static final String WEDM_DISABLE_CERTIFICATE_CHECK;
+    public static final boolean EDMRELATIVEPATHS;
 
     /**
      * On Windows you could set EDL_DIR to a remote ExpanDrive mount say
@@ -80,6 +81,11 @@ public class EDLParser {
                 }
             }
         }
+        
+        // EDM Version 1-12-105J, ca. June 2021, supports this environment variable
+        // to enable relative path support.
+        EDMRELATIVEPATHS = "yes".equals(System.getenv("EDMRELATIVEPATHS"));
+        LOGGER.log(Level.INFO, "EDMRELATIVEPATHS=" + (EDMRELATIVEPATHS ? "yes" : "no"));
     }
 
     /**
@@ -182,6 +188,9 @@ public class EDLParser {
      * @return URL for name relative to parent, for example "http://some/path/sub/another.edl" or <code>null</code>
      */
     public static URL getRelativeURL(final URL parent, String name) {
+        if (! EDMRELATIVEPATHS)
+            return null;
+        
         if (parent == null)
             return null;
         
@@ -250,7 +259,7 @@ public class EDLParser {
             }
         }
         
-        // Check for relative path as supported by EDM since ~June 2021
+        // Check for relative path
         final URL relative = getRelativeURL(parent, name);
         if (relative != null  &&  testAccess(relative))
             return relative;

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -146,17 +146,11 @@ public class ScreenParser extends EDLParser {
                                     // Check if related display links need to be resolved
                                     // relative to this display
                                     if (last instanceof RelatedDisplay  &&  url != null) { 
-                                        try {
-                                            final RelatedDisplay related = (RelatedDisplay) last;
-                                            final File parent_dir = new File(url.toURI()).getParentFile();
-                                            for (int i=0; i<related.displayFileName.length; ++i) {
-                                                final File relative = new File(parent_dir, related.displayFileName[i]);
-                                                if (relative.canRead())
-                                                    related.displayFileName[i] = relative.getAbsolutePath();
-                                            }
-                                        }
-                                        catch (Exception ex) {
-                                            LOGGER.log(Level.FINER, "Cannot check relative link for parent " + url, ex);
+                                        final RelatedDisplay related = (RelatedDisplay) last;
+                                        for (int i=0; i<related.displayFileName.length; ++i) {
+                                            final URL relative = EDLParser.getRelativeURL(url, related.displayFileName[i]);
+                                            if (relative != null  &&  EDLParser.testAccess(relative))
+                                                related.displayFileName[i] = relative.toExternalForm();
                                         }
                                     }
                                     

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -232,7 +232,7 @@ public class ScreenParser extends EDLParser {
         // less if the resource is remote.
         int max_recurse = 5;
         if (url.getProtocol().startsWith("http")) {
-            max_recurse = 1;
+            max_recurse = 2;
         }
         if (recursionLevel < max_recurse) {
             for (EmbeddedScreen embedded : embeddedScreens) {

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -27,6 +27,7 @@ import org.jlab.wedm.persistence.model.Screen;
 import org.jlab.wedm.persistence.model.WEDMWidget;
 import org.jlab.wedm.widget.ScreenProperties;
 import org.jlab.wedm.widget.UnknownWidget;
+import org.jlab.wedm.widget.html.ActiveImage;
 import org.jlab.wedm.widget.html.RelatedDisplay;
 
 public class ScreenParser extends EDLParser {
@@ -143,14 +144,21 @@ public class ScreenParser extends EDLParser {
                                     last.parseTraits(traits, properties);
                                     last.performColorRuleCorrection();
                                     
-                                    // Check if related display links need to be resolved
-                                    // relative to this display
-                                    if (last instanceof RelatedDisplay  &&  url != null) { 
-                                        final RelatedDisplay related = (RelatedDisplay) last;
-                                        for (int i=0; i<related.displayFileName.length; ++i) {
-                                            final URL relative = EDLParser.getRelativeURL(url, related.displayFileName[i]);
+                                    // Check if links need to be resolved relative to this display
+                                    if (url != null) {
+                                        if (last instanceof RelatedDisplay) { 
+                                            final RelatedDisplay related = (RelatedDisplay) last;
+                                            for (int i=0; i<related.displayFileName.length; ++i) {
+                                                final URL relative = EDLParser.getRelativeURL(url, related.displayFileName[i]);
+                                                if (relative != null  &&  EDLParser.testAccess(relative))
+                                                    related.displayFileName[i] = relative.toExternalForm();
+                                            }
+                                        }
+                                        else if (last instanceof ActiveImage) { 
+                                            final ActiveImage image = (ActiveImage) last;
+                                            final URL relative = EDLParser.getRelativeURL(url, image.file);
                                             if (relative != null  &&  EDLParser.testAccess(relative))
-                                                related.displayFileName[i] = relative.toExternalForm();
+                                                image.file = relative.toExternalForm();
                                         }
                                     }
                                     

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -230,7 +230,7 @@ public class ScreenParser extends EDLParser {
                         }
                     } else if (embedded instanceof ActivePictureInPicture) {
                         if (embedded.file != null && "file".equals(embedded.displaySource)) {
-                            Screen s = this.parse(EDLParser.getEdlURL(embedded.file), colorList, recursionLevel + 1);
+                            Screen s = this.parse(EDLParser.getURL(url, embedded.file, true), colorList, recursionLevel + 1);
                             s.setScreenProperties(embedded);
                             embedded.screen = s;
                         } else if ("menu".equals(embedded.displaySource)) { // Use filePv to determine which menu item to use

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -1,5 +1,6 @@
 package org.jlab.wedm.persistence.io;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -26,6 +27,7 @@ import org.jlab.wedm.persistence.model.Screen;
 import org.jlab.wedm.persistence.model.WEDMWidget;
 import org.jlab.wedm.widget.ScreenProperties;
 import org.jlab.wedm.widget.UnknownWidget;
+import org.jlab.wedm.widget.html.RelatedDisplay;
 
 public class ScreenParser extends EDLParser {
 
@@ -140,6 +142,24 @@ public class ScreenParser extends EDLParser {
                                     //        last.getClass().getSimpleName());
                                     last.parseTraits(traits, properties);
                                     last.performColorRuleCorrection();
+                                    
+                                    // Check if related display links need to be resolved
+                                    // relative to this display
+                                    if (last instanceof RelatedDisplay  &&  url != null) { 
+                                        try {
+                                            final RelatedDisplay related = (RelatedDisplay) last;
+                                            final File parent_dir = new File(url.toURI()).getParentFile();
+                                            for (int i=0; i<related.displayFileName.length; ++i) {
+                                                final File relative = new File(parent_dir, related.displayFileName[i]);
+                                                if (relative.canRead())
+                                                    related.displayFileName[i] = relative.getAbsolutePath();
+                                            }
+                                        }
+                                        catch (Exception ex) {
+                                            LOGGER.log(Level.FINER, "Cannot check relative link for parent " + url, ex);
+                                        }
+                                    }
+                                    
                                     traits = null;
                                     //last = null; // We can no longer clear last obj since widgets like RegTextupdateClass have multiple sets of properties
                                     break;


### PR DESCRIPTION
Hello Ryan,

A recent EDM update added support for relative path names.
When enabled via environment variable "EDMRELATIVEPATHS=yes", EDM will try to resolve images, related display links and embedded display paths relative to the location of the current display.

This uses the same environment variable. Unless defined and set to "yes", nothing should change.
It adds a `getURL` variant which takes the parent display path and then uses that to check if image, embedded display and related display links can be resolved and updated to use the name relative to the parent display.