### PR TITLE
Parse symbol state value ranges as float, not integer

### DIFF
--- a/src/main/java/org/jlab/wedm/persistence/io/TraitParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/TraitParser.java
@@ -144,6 +144,38 @@ public class TraitParser {
         return result;
     }
 
+    public static float[] parseFloatArray(Map<String, String> traits, int elementCount, String key) {
+        String value = traits.get(key);
+        float[] result = null;
+        try {
+            if (value != null) {
+                String[] lines = value.split("\n");
+
+                // EDM arrays are specified as "index  value".
+                // Default value for missing elements is zero.
+                result = new float[elementCount];
+
+                for (int i = 0; i < lines.length; i++) {
+                    String[] tks = lines[i].split("\\s+");
+                    int index = Integer.parseInt(tks[0]);
+
+                    if (index >= 0 && index <= MAX_ARRAY_SIZE) {
+                        result[index] = Float.parseFloat(tks[1]);
+                    } else {
+                        throw new IllegalArgumentException(
+                                "index number out of range: " + index);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.FINEST, "Unable to parse float; key: {0}; value: {1}", new Object[]{key,
+                value});
+        }
+
+        return result;
+    }
+    
+    
     public static String[] parseStringArray(Map<String, String> traits, int elementCount,
             String key) {
         String value = traits.get(key);

--- a/src/main/java/org/jlab/wedm/widget/ActiveSymbol.java
+++ b/src/main/java/org/jlab/wedm/widget/ActiveSymbol.java
@@ -22,8 +22,8 @@ public class ActiveSymbol extends EmbeddedScreen {
     private static final Logger LOGGER = Logger.getLogger(ActiveSymbol.class.getName());
 
     public int numStates;
-    public int[] minValues;
-    public int[] maxValues;
+    public float[] minValues;
+    public float[] maxValues;
     public String[] controlPvs;
     public boolean useOriginalSize = false;
     public boolean useOriginalColors = false;
@@ -33,8 +33,8 @@ public class ActiveSymbol extends EmbeddedScreen {
         super.parseTraits(traits, properties);
 
         numStates = TraitParser.parseInt(traits, "numStates", 0);
-        minValues = TraitParser.parseIntArray(traits, numStates, "minValues");
-        maxValues = TraitParser.parseIntArray(traits, numStates, "maxValues");
+        minValues = TraitParser.parseFloatArray(traits, numStates, "minValues");
+        maxValues = TraitParser.parseFloatArray(traits, numStates, "maxValues");
 
         controlPvs = TraitParser.parseStringArray(traits, 1, "controlPvs");
 


### PR DESCRIPTION
Fixes #24: The min..max value for each state of a symbol was parsed as `int` and failed when the values happened to be floating point.