### PR TITLE
Relative path fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ EDMRELATIVEPATHS=yes
 When relative paths are enabled, the names of embedded displays, images and
 links to related displays can be resolved relative to the display which contains them.
 
+By default, WEDM will test access to each relative path and otherwise fall back to
+the search path.
+These access checks take considerable time.
+If a site uses relative path names and no longer relies on a search path,
+these checks can be disabled via
+
+```
+WEDM_DISABLE_RELATIVEPATHS_CHECK=yes
+```
+
+When both `EDMRELATIVEPATHS` and `WEDM_DISABLE_RELATIVEPATHS_CHECK` are set to `yes`,
+all file references are assumed to be relative without checking access.
+
 ### Context Prefix
 When proxying WEDM it is sometimes useful to have multiple instances accessible via the same host via separate context paths.  In order to return correct links to resources an instance proxied with a namespacing prefix needs to be aware of the prefix.  The environment variable **CONTEXT_PREFIX** does this.  For example at Jefferson Lab we use a single proxy server for multiple departments each with their own instance of WEDM, and each configured with a prefix such as "/fel", "/chl", "/itf", and "/srf" ("/ops" uses default/empty prefix).
 

--- a/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
+++ b/src/main/java/org/jlab/wedm/persistence/io/ScreenParser.java
@@ -150,14 +150,14 @@ public class ScreenParser extends EDLParser {
                                             final RelatedDisplay related = (RelatedDisplay) last;
                                             for (int i=0; i<related.displayFileName.length; ++i) {
                                                 final URL relative = EDLParser.getRelativeURL(url, related.displayFileName[i]);
-                                                if (relative != null  &&  EDLParser.testAccess(relative))
+                                                if (relative != null)
                                                     related.displayFileName[i] = relative.toExternalForm();
                                             }
                                         }
                                         else if (last instanceof ActiveImage) { 
                                             final ActiveImage image = (ActiveImage) last;
                                             final URL relative = EDLParser.getRelativeURL(url, image.file);
-                                            if (relative != null  &&  EDLParser.testAccess(relative))
+                                            if (relative != null)
                                                 image.file = relative.toExternalForm();
                                         }
                                     }
@@ -244,7 +244,7 @@ public class ScreenParser extends EDLParser {
 
                     if (embedded instanceof ActiveSymbol) {
                         if (embedded.file != null) {
-                            Screen s = this.parse(EDLParser.getEdlURL(embedded.file), colorList, recursionLevel + 1);
+                            Screen s = this.parse(EDLParser.getURL(url, embedded.file, true), colorList, recursionLevel + 1);
                             s.setScreenProperties(embedded);
                             embedded.screen = s;
                         } else {
@@ -264,7 +264,7 @@ public class ScreenParser extends EDLParser {
                                     //LOGGER.log(Level.FINEST, "file {0}: {1}", new Object[]{i, f});
                                     if (f != null) {
                                         try {
-                                            Screen s2 = this.parse(EDLParser.getEdlURL(f), colorList, recursionLevel + 1);
+                                            Screen s2 = this.parse(EDLParser.getURL(url, f, true), colorList, recursionLevel + 1);
 
                                             s2.embeddedIndex = i;
 


### PR DESCRIPTION
At SNS we've converted most EDM displays to a setup that uses relative path names for the links between files, so we set EDMRELATIVEPATHS=yes, and EDMDATAFILES has just one entry, the root of the display folders.

Testing that with WEDM revealed that I had missed support for relative paths in the related display 'menu' and 'ActiveSymbol'.

Also found that the previous implementation which tests the constructed relative path is slow.
When the files "work" with regular EDM, i.e. the relative links to embedded screens and related displays are correct, WEDM can skip the check to load screens much faster when opened for the first time.
.. of course at the cost of potentially failing later when a user pushes the button to open a related display in case the link was in fact wrong.
So added a new WEDM_DISABLE_RELATIVEPATHS_CHECK that allows disabling the access
test.